### PR TITLE
Added SEE ALSO to doc. RT#100575

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.33    ??
+* Added SEE ALSO section to documentation. RT#100575
+
 0.32    Thu Feb 20 22:53:19 GMT 2014
 * Fix tests to support statically built perls
 

--- a/lib/Module/Load.pm
+++ b/lib/Module/Load.pm
@@ -334,6 +334,25 @@ C<Module::Load> cannot do implicit imports, only explicit imports.
 to import from a module, even if the functions are in that modules'
 C<@EXPORT>)
 
+=head1 SEE ALSO
+
+L<Module::Runtime> provides functions for loading modules,
+checking the validity of a module name,
+converting a module name to partial C<.pm> path,
+and related utility functions.
+
+L<"require" in perlfunc|https://metacpan.org/pod/perlfunc#require>
+and
+L<"use" in perlfunc|https://metacpan.org/pod/perlfunc#use>.
+
+L<Mojo::Loader> is a "class loader and plugin framework",
+and is included in the
+L<Mojolicious|https://metacpan.org/release/Mojolicious> distribution.
+
+L<Module::Loader> is a module for finding and loading modules
+in a given namespace, inspired by C<Mojo::Loader>.
+
+
 =head1 ACKNOWLEDGEMENTS
 
 Thanks to Jonas B. Nielsen for making explicit imports work.


### PR DESCRIPTION
Hi,

This adds a SEE ALSO section to the doc, with entries for `Module::Runtime`, two similar modules, and `perlfunc` doc for `use` and `require`.

This addresses [RT#100575](https://rt.cpan.org/Public/Bug/Display.html?id=100575).

Cheers,
Neil
