### PR TITLE
Added functionality to ensure past modules don't break on load() after

### DIFF
--- a/t/03-dot_in_inc_disabled.t
+++ b/t/03-dot_in_inc_disabled.t
@@ -1,0 +1,33 @@
+BEGIN {
+    if( $ENV{PERL_CORE} ) {
+        chdir '../lib/Module/Load' if -d '../lib/Module/Load';
+        unshift @INC, '../../..';
+    }
+}
+
+BEGIN { chdir 't' if -d 't' }
+
+use strict;
+use lib qw[../lib to_load];
+
+use Test::More;
+use Module::Load dot_in_inc => 0;
+
+{
+    open my $fh, '>', 'Incdot.pm' or die $!;
+    print $fh "package Incdot; 1;";
+    close $fh;
+
+    is +(grep { $_ eq '.' } @INC), 0, "local dir not in \@INC after loading Module::Load";
+
+    my $ok = eval { load 'Incdot.pm'; 1; };
+    is $ok, undef, "load() doesn't load a file in local dir with use_inc_dot false";
+
+    my $ok = eval { load Incdot; 1; };
+    is $ok, undef, "load() doesn't load a module in local dir with use_inc_dot false";
+
+    unlink 'Incdot.pm' or die $!;
+    is -f 'Incdot.pm', undef, "sample module file removed ok";
+}
+
+done_testing();

--- a/t/04-dot_in_inc_default.t
+++ b/t/04-dot_in_inc_default.t
@@ -1,0 +1,42 @@
+BEGIN {
+    if( $ENV{PERL_CORE} ) {
+        chdir '../lib/Module/Load' if -d '../lib/Module/Load';
+        unshift @INC, '../../..';
+    }
+}
+
+BEGIN { chdir 't' if -d 't' }
+
+use strict;
+use lib qw[../lib to_load];
+
+use Test::More;
+
+BEGIN {
+    @INC = grep { $_ ne '.' } @INC;
+    is +(grep { $_ eq '.' } @INC), 0, "local dir not in \@INC prior to loading Module::Load";
+}
+
+use Module::Load;
+
+{
+    is +(grep { $_ eq '.' } @INC), 1, "local dir in \@INC after loading Module::Load";
+
+    open my $fh, '>', 'Incdot.pm' or die $!;
+    print $fh "package Incdot; 1;";
+    close $fh;
+
+    load 'Incdot.pm';
+
+    my $ok = eval { load 'Incdot.pm'; 1; };
+    is $ok, 1, "load() loads a file in local dir ok with no '.' in \@INC";
+
+    $ok = eval { load Incdot; 1; };
+    is $ok, 1, "load() loads a module in local dir ok with no '.' in \@INC";
+
+    unlink 'Incdot.pm' or die $!;
+    is -f 'Incdot.pm', undef, "sample module file removed ok";
+
+}
+
+done_testing();


### PR DESCRIPTION
inc-dot is changed in 5.26.0

- use Module::Load; adds '.' to @INC if it's not there by default
- use Module::Load dot_in_inc => 0; removes it
- added tests
- updated SYNOPSIS
- added note in Caveats